### PR TITLE
DEV: Move setting descriptions to en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,11 @@
 en:
   theme_metadata:
     description: "This component better distinguishes a public reply from a whisper."
+    settings:
+      whisper_only: "Only show the warning button when composing a whisper; hide it for public replies."
+      show_in_read_restricted_categories: "Automatically show the warning when replying in categories that are not publicly visible."
+      show_in_group_pms: "Automatically show the warning when replying in a PM where you are a member of one of the allowed groups."
+      restrict_to_groups: "Limit the warning to members of specific groups. Leave empty to show for all users who can whisper."
+      restrict_to_categories: "Additional categories where the warning should appear. Works alongside the automatic read-restricted setting."
   public_reply: "reply will be visible"
   whispering: "whispering"

--- a/settings.yml
+++ b/settings.yml
@@ -1,31 +1,17 @@
 whisper_only:
   default: false
   type: bool
-  label: "Whisper only"
-  description: "Only show the warning button when composing a whisper; hide it for public replies."
-
 show_in_read_restricted_categories:
   default: true
   type: bool
-  label: "Show in read-restricted categories"
-  description: "Automatically show the warning when replying in categories that are not publicly visible."
-
 show_in_group_pms:
   default: true
   type: bool
-  label: "Show in group PMs"
-  description: "Automatically show the warning when replying in a PM where you are a member of one of the allowed groups."
-
 restrict_to_groups:
   default: ""
   type: list
   list_type: group
-  label: "Restrict to groups"
-  description: "Limit the warning to members of specific groups. Leave empty to show for all users who can whisper."
-
 restrict_to_categories:
   default: ""
   type: list
   list_type: category
-  label: "Restrict to categories"
-  description: "Additional categories where the warning should appear. Works alongside the automatic read-restricted setting."


### PR DESCRIPTION
I moved the setting descriptions from the `settings.yml` file to `en.yml` so that all translatable strings are centralized and can be managed via Crowdin once the component is added there.

I also removed the `label` attribute. I couldn't find out the syntax for using it in `en.yml`. In fact I couldn't find any documentation about its usage in the official guide: https://meta.discourse.org/t/add-settings-to-your-discourse-theme/82557. In practice, it also did not appear to have any effect in the UI. Even after modifying the labels, the theme settings interface still displayed the setting name derived from the setting key instead. 
Is there any documentation available on this?