### PR TITLE
FIX: Use canToggleWhisper instead of removed showWhisperToggle

### DIFF
--- a/javascripts/discourse/components/whisper-warning.gjs
+++ b/javascripts/discourse/components/whisper-warning.gjs
@@ -14,7 +14,7 @@ export default class WhisperWarning extends Component {
     const composerAction = model.get("action");
 
     if (
-      !this.composer.showWhisperToggle ||
+      !this.composer.canToggleWhisper ||
       composerAction === "createTopic" ||
       composerAction === "createSharedDraft"
     ) {


### PR DESCRIPTION
Discourse removed showWhisperToggle from the composer service in the new post type dropdown work (https://github.com/discourse/discourse/pull/38068), so the warning never rendered. Switch to canToggleWhisper, which checks the same thing.