### PR TITLE
DEV: Update whisper toggle helper for new composer actions UI

### DIFF
--- a/spec/system/whisper_warning_spec.rb
+++ b/spec/system/whisper_warning_spec.rb
@@ -25,8 +25,14 @@ RSpec.describe "Whisper Warning" do
   end
 
   def enable_whisper
-    find(".composer-actions").click
-    find("[data-value='toggle_whisper']").click
+    # Core exposes a dedicated whisper toggle button with the new composer
+    # actions UI; fall back to the composer actions dropdown on older versions.
+    if page.has_css?(".composer-whisper-indicator")
+      find(".composer-whisper-indicator").click
+    else
+      find(".composer-actions").click
+      find("[data-value='toggle_whisper']").click
+    end
   end
 
   context "with default settings" do


### PR DESCRIPTION
The `enable_whisper` system spec helper toggled whisper mode by clicking the old select-kit `.composer-actions` dropdown. Discourse core has since moved the composer actions behind the `enable_new_composer_actions` setting — which is enabled in the test environment — replacing that dropdown with a dedicated `.composer-whisper-indicator` toggle button. The helper could no longer find `.composer-actions` and raised `Capybara::ElementNotFound`, failing the two tests that enable whispering:

  - "with default settings shows the whispering class when whispering"
  - "with whisper_only enabled shows the button when composing a whisper"

Click the new whisper toggle button when it is present, falling back to the legacy dropdown so the spec passes on both the new and old composer UI.