### PR TITLE
DEV: Add group-based setting metadata

### DIFF
--- a/javascripts/discourse/components/whisper-warning.gjs
+++ b/javascripts/discourse/components/whisper-warning.gjs
@@ -85,10 +85,16 @@ export default class WhisperWarning extends Component {
     );
   }
 
-  // Returns true if restrict_to_groups is empty, or the current user is a
-  // member of at least one specified group. Matches by both group ID and name
-  // to handle either storage format from the list_type: group setting.
   get isInAllowedGroup() {
+    if (Object.hasOwn(settings, "user_in_restrict_to_groups")) {
+      return settings.user_in_restrict_to_groups;
+    }
+
+    // TODO (martin) Remove this fallback after resolve_group_membership
+    // from core is available everywhere
+    //
+    // Old behaviour was to allow all logged-in users if no groups were configured,
+    // new behaviour is to allow logged in users only if they are in the configured group.
     const groups = this.parseListSetting(settings.restrict_to_groups);
 
     if (groups.length === 0) {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,7 +5,7 @@ en:
       whisper_only: "Only show the warning button when composing a whisper; hide it for public replies."
       show_in_read_restricted_categories: "Automatically show the warning when replying in categories that are not publicly visible."
       show_in_group_pms: "Automatically show the warning when replying in a PM where you are a member of one of the allowed groups."
-      restrict_to_groups: "Limit the warning to members of specific groups. Leave empty to show for all users who can whisper."
+      restrict_to_groups: "Limit the warning to members of specific groups."
       restrict_to_categories: "Additional categories where the warning should appear. Works alongside the automatic read-restricted setting."
   public_reply: "reply will be visible"
   whispering: "whispering"

--- a/migrations/settings/0001-migrate-blank-restrict-to-groups.js
+++ b/migrations/settings/0001-migrate-blank-restrict-to-groups.js
@@ -1,0 +1,10 @@
+export default function migrate(settings) {
+  if (
+    settings.has("restrict_to_groups") &&
+    !String(settings.get("restrict_to_groups") ?? "").trim()
+  ) {
+    settings.set("restrict_to_groups", "1|2");
+  }
+
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -8,9 +8,11 @@ show_in_group_pms:
   default: true
   type: bool
 restrict_to_groups:
-  default: ""
+  default: "1|2"
   type: list
   list_type: group
+  resolve_group_membership: true
+  disallowed_groups: "4"
 restrict_to_categories:
   default: ""
   type: list

--- a/spec/system/whisper_warning_spec.rb
+++ b/spec/system/whisper_warning_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Whisper Warning" do
   fab!(:admin)
   fab!(:moderator)
-  fab!(:group)
+  fab!(:hint_group, :group)
   fab!(:category)
   fab!(:read_restricted_category) { Fabricate(:private_category, group: Group[:staff]) }
   fab!(:topic) do
@@ -14,7 +14,7 @@ RSpec.describe "Whisper Warning" do
 
   before do
     SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
-    group.add(moderator)
+    hint_group.add(moderator)
     sign_in(moderator)
   end
 
@@ -25,8 +25,7 @@ RSpec.describe "Whisper Warning" do
   end
 
   def enable_whisper
-    find(".composer-actions").click
-    find("[data-value='toggle_whisper']").click
+    find("#reply-control .composer-whisper-indicator").click
   end
 
   context "with default settings" do
@@ -107,11 +106,12 @@ RSpec.describe "Whisper Warning" do
 
   context "with restrict_to_groups set" do
     before do
-      theme.update_setting(:restrict_to_groups, group.name)
+      theme.update_setting(:restrict_to_groups, hint_group.id)
       theme.save!
     end
 
     it "shows for users in the specified group" do
+      hint_group.add(admin)
       open_composer_for
       expect(page).to have_css(".whisper-hint")
     end


### PR DESCRIPTION
Since the introduction of `resolve_group_membership` and
`disallowed_groups` metadata in [discourse/discourse#41792](https://github.com/discourse/discourse/pull/41792),
[discourse/discourse#41756](https://github.com/discourse/discourse/pull/41756), and [discourse/discourse-copy-post#37](https://github.com/discourse/discourse-copy-post/pull/37),
we are updating existing theme components to take advantage
of these new APIs in an effort to support the removal of the `everyone`
pseudogroup from core and increase clarity around group-based settings.

See also https://meta.discourse.org/t/-/402273
